### PR TITLE
Enables RTLTCP and file input build

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -137,7 +137,7 @@ endif(ENABLE_OSMOSDR)
 ########################################################################
 # Setup File component
 ########################################################################
-GR_REGISTER_COMPONENT("IQ File Source & Sink" ENABLE_FILE GNURADIO_BLOCKS_FOUND)
+GR_REGISTER_COMPONENT("IQ File Source & Sink" ENABLE_FILE gnuradio-blocks_FOUND)
 if(ENABLE_FILE)
 GR_INCLUDE_SUBDIRECTORY(file)
 endif(ENABLE_FILE)
@@ -153,7 +153,7 @@ endif(ENABLE_RTL)
 ########################################################################
 # Setup RTL_TCP component
 ########################################################################
-GR_REGISTER_COMPONENT("RTLSDR TCP Client" ENABLE_RTL_TCP GNURADIO_BLOCKS_FOUND)
+GR_REGISTER_COMPONENT("RTLSDR TCP Client" ENABLE_RTL_TCP gnuradio-blocks_FOUND)
 if(ENABLE_RTL_TCP)
 GR_INCLUDE_SUBDIRECTORY(rtl_tcp)
 endif(ENABLE_RTL_TCP)


### PR DESCRIPTION
Without this patch, gr-osmosdr builds, but doesn't support RTL TCP server or file input.  This leads to the "No supported devices found to pick from" error at startup of gqrx.

Looking at the diffs for gr3.8 support, it seems like a couple of `GNURADIO_BLOCKS_FOUND` references were missed when the `CMakeLists.txt` files were updated.  Updating these to the new variable name fixes both RTL TCP and file input support, and gets my trunk of gqrx to run cleanly without hardware attached locally.